### PR TITLE
Correction d'un bug lors de la création des créations

### DIFF
--- a/app/Services/CreationConversionService.php
+++ b/app/Services/CreationConversionService.php
@@ -18,11 +18,18 @@ class CreationConversionService
     {
         $this->validateDraft($draft);
 
-        $creation = Creation::create($this->mapDraftAttributes($draft));
+        if ($draft->originalCreation()->exists()) {
+            $creation = $draft->originalCreation;
+            $creation->update($this->mapDraftAttributes($draft));
 
+            $this->recreateFeatures($draft, $creation);
+            $this->recreateScreenshots($draft, $creation);
+        } else {
+            $creation = Creation::create($this->mapDraftAttributes($draft));
+            $this->createFeatures($draft, $creation);
+            $this->createScreenshots($draft, $creation);
+        }
         $this->syncRelationships($draft, $creation);
-        $this->createFeatures($draft, $creation);
-        $this->createScreenshots($draft, $creation);
 
         return $creation;
     }

--- a/tests/Feature/Models/Creation/CreationControllerTest.php
+++ b/tests/Feature/Models/Creation/CreationControllerTest.php
@@ -94,8 +94,6 @@ class CreationControllerTest extends TestCase
             'draft_id' => $draft->id,
         ]);
 
-        echo $response->getContent();
-
         $response->assertUnprocessable();
     }
 
@@ -114,7 +112,6 @@ class CreationControllerTest extends TestCase
             'draft_id' => $draft->id,
         ]);
 
-        echo $response->getContent();
         $response->assertServerError();
     }
 

--- a/tests/Feature/Models/Picture/PictureControllerTest.php
+++ b/tests/Feature/Models/Picture/PictureControllerTest.php
@@ -56,7 +56,6 @@ class PictureControllerTest extends TestCase
             'picture' => $uploadedFile,
         ]);
 
-        echo $response->getContent();
         $response->assertCreated();
     }
 


### PR DESCRIPTION
This pull request introduces significant changes to enhance the handling of creation drafts, improve the user interface for publishing drafts, and expand test coverage. The most important updates include modifying the draft-to-creation conversion logic, adding a "Publish" button to the UI, and implementing a new test for converting drafts to existing creations.

### Changes to draft-to-creation conversion logic:
* Updated `convertDraftToCreation` in `CreationConversionService` to handle updates to existing creations by checking if the draft is linked to an original creation. This includes updating attributes and recreating features/screenshots for existing creations.

### UI improvements for publishing drafts:
* Added `isPublishing` state and a new `publishDraft` function in `EditPage.vue` to enable publishing drafts directly from the dashboard. This includes error handling and success/error toast notifications. [[1]](diffhunk://#diff-a964dc8b5f256a34536dcda5cec7f46bb0edaf162d884c02fbef724dbbde2164R56) [[2]](diffhunk://#diff-a964dc8b5f256a34536dcda5cec7f46bb0edaf162d884c02fbef724dbbde2164R236-R275)
* Introduced a "Publish" button in the form, which is conditionally displayed for existing drafts and disabled during submission or publishing.

### Test coverage enhancements:
* Added a new test, `test_convert_draft_to_existing_creation`, in `CreationConversionServiceTest` to verify that drafts can correctly update existing creations, including their relationships and attributes.
* Removed unnecessary `echo` statements from various test cases to clean up test output. [[1]](diffhunk://#diff-ab5c30dce345981d354f0a6eb28f3ba232e16ff0201c626d028c28ea9530bd59L97-L98) [[2]](diffhunk://#diff-ab5c30dce345981d354f0a6eb28f3ba232e16ff0201c626d028c28ea9530bd59L117) [[3]](diffhunk://#diff-f289517fa18a193887db4c5ec3805cea37f641493052670561735b0e47e44844L59)