### PR TITLE
fix(EditPage): handle date formatting and empty ended_at values

### DIFF
--- a/resources/js/pages/dashboard/creations/EditPage.vue
+++ b/resources/js/pages/dashboard/creations/EditPage.vue
@@ -127,8 +127,8 @@ const { isFieldDirty, handleSubmit, setFieldValue, meta } = useForm({
         short_description_content: shortDescriptionContent,
         full_description_content: fullDescriptionContent,
         featured: currentCreationDraft.value?.featured ?? false,
-        started_at: currentCreationDraft.value?.started_at ?? today,
-        ended_at: currentCreationDraft.value?.ended_at ?? null,
+        started_at: currentCreationDraft.value?.started_at ? currentCreationDraft.value.started_at.split('T')[0] : today,
+        ended_at: currentCreationDraft.value?.ended_at ? currentCreationDraft.value.ended_at.split('T')[0] : null,
     },
 });
 
@@ -176,8 +176,13 @@ const onSubmit = handleSubmit(async (formValues) => {
     isSubmitting.value = true;
 
     try {
-        const payload = {
+        const processedFormValues = {
             ...formValues,
+            ended_at: formValues.ended_at === '' ? null : formValues.ended_at,
+        };
+
+        const payload = {
+            ...processedFormValues,
             original_creation_id: originalCreationId.value,
         };
 


### PR DESCRIPTION
### **User description**
Format started_at and ended_at dates by splitting on 'T' character. Convert empty ended_at strings to null before submission. Update form values processing to ensure consistent data format.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix date formatting for `started_at` and `ended_at` fields

- Convert empty `ended_at` values to null before submission

- Ensure consistent data format in form processing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EditPage.vue</strong><dd><code>Fix and normalize date handling in creation edit form</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/pages/dashboard/creations/EditPage.vue

<li>Format <code>started_at</code> and <code>ended_at</code> to 'YYYY-MM-DD' by splitting at 'T'<br> <li> Convert empty <code>ended_at</code> strings to null before form submission<br> <li> Refactor form value processing for consistent data handling


</details>


  </td>
  <td><a href="https://github.com/SofianeLasri/laravel-personal-website/pull/25/files#diff-a964dc8b5f256a34536dcda5cec7f46bb0edaf162d884c02fbef724dbbde2164">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>