### PR TITLE
fix(screenshot): make caption field nullable and handle null values

### DIFF
--- a/database/migrations/2025_03_08_145433_create_screenshots_table.php
+++ b/database/migrations/2025_03_08_145433_create_screenshots_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignIdFor(Creation::class)->constrained()->cascadeOnDelete();
             $table->foreignIdFor(Picture::class)->constrained('pictures')->cascadeOnDelete();
-            $table->foreignIdFor(TranslationKey::class, 'caption_translation_key_id')->nullable()->constrained('translation_keys');
+            $table->foreignIdFor(TranslationKey::class, 'caption_translation_key_id')->nullable()->constrained('translation_keys')->nullOnDelete();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_03_11_155449_create_creation_draft_screenshots_table.php
+++ b/database/migrations/2025_03_11_155449_create_creation_draft_screenshots_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignIdFor(CreationDraft::class)->constrained()->cascadeOnDelete();
             $table->foreignIdFor(Picture::class)->constrained('pictures')->cascadeOnDelete();
-            $table->foreignIdFor(TranslationKey::class, 'caption_translation_key_id')->nullable()->constrained('translation_keys');
+            $table->foreignIdFor(TranslationKey::class, 'caption_translation_key_id')->nullable()->constrained('translation_keys')->nullOnDelete();
             $table->timestamps();
         });
     }

--- a/tests/Feature/Models/Screenshot/CreationDraftScreenshotControllerTest.php
+++ b/tests/Feature/Models/Screenshot/CreationDraftScreenshotControllerTest.php
@@ -47,7 +47,7 @@ class CreationDraftScreenshotControllerTest extends TestCase
     }
 
     #[Test]
-    public function test_store_creates_new_screenshot_with_translation(): void
+    public function test_store_creates_new_screenshot_with_caption(): void
     {
         $picture = Picture::factory()->create();
 
@@ -74,6 +74,27 @@ class CreationDraftScreenshotControllerTest extends TestCase
             ->first();
 
         $this->assertEquals('Test Caption', $translation->text);
+    }
+
+    #[Test]
+    public function test_store_creates_new_screenshot_without_caption(): void
+    {
+        $picture = Picture::factory()->create();
+
+        $response = $this->postJson(
+            route('dashboard.api.creation-drafts.draft-screenshots.store', $this->draft),
+            [
+                'picture_id' => $picture->id,
+            ]
+        );
+
+        $response->assertCreated()
+            ->assertJsonPath('picture_id', $picture->id);
+
+        $this->assertDatabaseHas('creation_draft_screenshots', [
+            'creation_draft_id' => $this->draft->id,
+            'picture_id' => $picture->id,
+        ]);
     }
 
     #[Test]
@@ -123,6 +144,25 @@ class CreationDraftScreenshotControllerTest extends TestCase
             ->first();
 
         $this->assertEquals('Updated Caption', $translation->text);
+    }
+
+    #[Test]
+    public function test_update_with_no_caption_removes_caption_translation_id(): void
+    {
+        $screenshot = CreationDraftScreenshot::factory()->withCaption()->create();
+
+        $response = $this->putJson(
+            route('dashboard.api.draft-screenshots.update', $screenshot),
+            [
+                'caption' => null,
+                'locale' => 'en',
+            ]
+        );
+
+        $response->assertOk();
+
+        $screenshot->refresh();
+        $this->assertNull($screenshot->caption_translation_key_id);
     }
 
     #[Test]


### PR DESCRIPTION
### **User description**
Update migration files to set nullOnDelete for caption_translation_key_id. Modify CreationDraftScreenshotController to handle null caption values:
- Skip translation creation when caption is empty
- Delete caption translation when updating with null Add tests for storing/updating screenshots without captions.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Make `caption_translation_key_id` nullable and handle null captions
  - Update migrations to set `nullOnDelete` for caption translation keys
  - Adjust controller logic to skip translation creation if caption is empty
  - Remove caption translation when updating with null caption

- Add and update tests for screenshots without captions
  - Test storing screenshots without captions
  - Test updating screenshots to remove captions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreationDraftScreenshotController.php</strong><dd><code>Handle nullable captions in screenshot creation and update</code></dd></summary>
<hr>

app/Http/Controllers/Admin/Api/CreationDraftScreenshotController.php

<li>Refactored to skip translation creation if caption is empty<br> <li> Set <code>caption_translation_key_id</code> to null if no caption provided<br> <li> On update, delete caption translation if caption is null<br> <li> Improved handling of nullable captions throughout controller


</details>


  </td>
  <td><a href="https://github.com/SofianeLasri/laravel-personal-website/pull/27/files#diff-3c6af5578972fa4fafe768f864df3f7c94c90bdc8e94b0c01c209ce030aa583f">+14/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>2025_03_08_145433_create_screenshots_table.php</strong><dd><code>Allow null on delete for screenshot caption translation key</code></dd></summary>
<hr>

database/migrations/2025_03_08_145433_create_screenshots_table.php

<li>Set <code>nullOnDelete</code> for <code>caption_translation_key_id</code> foreign key<br> <li> Ensures caption translation key can be null if deleted


</details>


  </td>
  <td><a href="https://github.com/SofianeLasri/laravel-personal-website/pull/27/files#diff-8ee3736e97bbfbffee194393f2f4684b8ae63fde38610b2cf886fe27b3e3c1a1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>2025_03_11_155449_create_creation_draft_screenshots_table.php</strong><dd><code>Allow null on delete for draft screenshot caption translation key</code></dd></summary>
<hr>

database/migrations/2025_03_11_155449_create_creation_draft_screenshots_table.php

<li>Set <code>nullOnDelete</code> for <code>caption_translation_key_id</code> foreign key<br> <li> Ensures draft screenshot captions can be null if translation key <br>deleted


</details>


  </td>
  <td><a href="https://github.com/SofianeLasri/laravel-personal-website/pull/27/files#diff-649726b34a9002a987a012a3be09c03464091651d735a6d650ee36f4803b4a04">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreationDraftScreenshotControllerTest.php</strong><dd><code>Add and update tests for optional screenshot captions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/Models/Screenshot/CreationDraftScreenshotControllerTest.php

<li>Added test for storing screenshots without captions<br> <li> Added test for updating screenshots to remove captions<br> <li> Updated test names for clarity regarding captions


</details>


  </td>
  <td><a href="https://github.com/SofianeLasri/laravel-personal-website/pull/27/files#diff-b626dcaee66b663f5efdaf1086f1140dfd5c1178972a17de52cf33cb3ea8a044">+41/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>