### PR TITLE
feat(models): add jpg support to optimized pictures

### DIFF
--- a/app/Console/Commands/OptimizePicturesCommand.php
+++ b/app/Console/Commands/OptimizePicturesCommand.php
@@ -31,6 +31,7 @@ class OptimizePicturesCommand extends Command
 
         if ($totalCount === 0) {
             $this->info('All pictures are already optimized!');
+
             return;
         }
 
@@ -39,7 +40,7 @@ class OptimizePicturesCommand extends Command
         $bar = $this->output->createProgressBar($totalCount);
         $bar->start();
 
-        $chunkSize = max(1, (int)$this->option('chunk'));
+        $chunkSize = max(1, (int) $this->option('chunk'));
 
         $pictureIdsToOptimize->chunk($chunkSize)->each(function ($ids) use ($bar) {
             foreach ($ids as $id) {

--- a/app/Http/Controllers/Admin/Api/TechnologyController.php
+++ b/app/Http/Controllers/Admin/Api/TechnologyController.php
@@ -27,7 +27,7 @@ class TechnologyController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255', 'unique:technologies,name'],
-            'type' => ['required', 'string', 'in:' . implode(',', TechnologyType::values())],
+            'type' => ['required', 'string', 'in:'.implode(',', TechnologyType::values())],
             'svg_icon' => ['required', 'string'],
             'locale' => ['required', 'string', 'in:en,fr'],
             'description' => ['required', 'string'],
@@ -60,7 +60,7 @@ class TechnologyController extends Controller
     {
         $request->validate([
             'name' => ['sometimes', 'string', 'max:255'],
-            'type' => ['sometimes', 'string', 'in:' . implode(',', TechnologyType::values())],
+            'type' => ['sometimes', 'string', 'in:'.implode(',', TechnologyType::values())],
             'svg_icon' => ['sometimes', 'string'],
             'locale' => ['required_with:description', 'string', 'in:en,fr'],
             'description' => ['sometimes', 'string'],

--- a/app/Http/Requests/Video/VideoUploadRequest.php
+++ b/app/Http/Requests/Video/VideoUploadRequest.php
@@ -13,7 +13,7 @@ class VideoUploadRequest extends FormRequest
                 'required',
                 'file',
                 'mimes:mp4,avi,mov,wmv,flv,webm,mkv',
-                'max:' . (1024 * 1024 * 1000), // 1000MB max
+                'max:'.(1024 * 1024 * 1000), // 1000MB max
             ],
             'name' => ['nullable', 'string', 'max:255'],
             'cover_picture_id' => ['required', 'exists:pictures,id'],

--- a/app/Models/OptimizedPicture.php
+++ b/app/Models/OptimizedPicture.php
@@ -50,6 +50,7 @@ class OptimizedPicture extends Model
     const FORMATS = [
         'avif',
         'webp',
+        'jpg',
     ];
 
     protected static function booted(): void

--- a/app/Models/Picture.php
+++ b/app/Models/Picture.php
@@ -50,7 +50,7 @@ class Picture extends Model
      * Get the optimized pictures for the picture.
      *
      * @param  string  $variant  thumbnail|small|medium|large|full
-     * @param  string  $format  avif|webp
+     * @param  string  $format  avif|webp|jpg
      */
     public function getOptimizedPicture(string $variant, string $format): ?OptimizedPicture
     {

--- a/app/Services/PublicControllersService.php
+++ b/app/Services/PublicControllersService.php
@@ -94,8 +94,8 @@ class PublicControllersService
      *      id: int,
      *      name: string,
      *      slug: string,
-     *      logo: array{filename: string, width: int|null, height: int|null, avif: array{thumbnail: string, small: string, medium: string, large: string, full: string}, webp: array{thumbnail: string, small: string, medium: string, large: string, full: string}},
-     *      coverImage: array{filename: string, width: int|null, height: int|null, avif: array{thumbnail: string, small: string, medium: string, large: string, full: string}, webp: array{thumbnail: string, small: string, medium: string, large: string, full: string}},
+     *      logo: array{filename: string, width: int|null, height: int|null, avif: array{thumbnail: string, small: string, medium: string, large: string, full: string}, webp: array{thumbnail: string, small: string, medium: string, large: string, full: string}, jpg: array{thumbnail: string, small: string, medium: string, large: string, full: string}},
+     *      coverImage: array{filename: string, width: int|null, height: int|null, avif: array{thumbnail: string, small: string, medium: string, large: string, full: string}, webp: array{thumbnail: string, small: string, medium: string, large: string, full: string}, jpg: array{thumbnail: string, small: string, medium: string, large: string, full: string}},
      *      startedAt: string,
      *      endedAt: string|null,
      *      startedAtFormatted: string|null,
@@ -135,8 +135,8 @@ class PublicControllersService
      *     id: int,
      *     name: string,
      *     slug: string,
-     *     logo: array{filename: string, width: int|null, height: int|null, avif: array{thumbnail: string, small: string, medium: string, large: string, full: string}, webp: array{thumbnail: string, small: string, medium: string, large: string, full: string}},
-     *     coverImage: array{filename: string, width: int|null, height: int|null, avif: array{thumbnail: string, small: string, medium: string, large: string, full: string}, webp: array{thumbnail: string, small: string, medium: string, large: string, full: string}},
+     *     logo: array{filename: string, width: int|null, height: int|null, avif: array{thumbnail: string, small: string, medium: string, large: string, full: string}, webp: array{thumbnail: string, small: string, medium: string, large: string, full: string}, jpg: array{thumbnail: string, small: string, medium: string, large: string, full: string}},
+     *     coverImage: array{filename: string, width: int|null, height: int|null, avif: array{thumbnail: string, small: string, medium: string, large: string, full: string}, webp: array{thumbnail: string, small: string, medium: string, large: string, full: string}, jpg: array{thumbnail: string, small: string, medium: string, large: string, full: string}},
      *     startedAt: string,
      *     endedAt: string|null,
      *     startedAtFormatted: string|null,
@@ -164,8 +164,8 @@ class PublicControllersService
      *     id: int,
      *     name: string,
      *     slug: string,
-     *     logo: array{filename: string, width: int|null, height: int|null, avif: array{thumbnail: string, small: string, medium: string, large: string, full: string}, webp: array{thumbnail: string, small: string, medium: string, large: string, full: string}},
-     *     coverImage: array{filename: string, width: int|null, height: int|null, avif: array{thumbnail: string, small: string, medium: string, large: string, full: string}, webp: array{thumbnail: string, small: string, medium: string, large: string, full: string}},
+     *     logo: array{filename: string, width: int|null, height: int|null, avif: array{thumbnail: string, small: string, medium: string, large: string, full: string}, webp: array{thumbnail: string, small: string, medium: string, large: string, full: string}, jpg: array{thumbnail: string, small: string, medium: string, large: string, full: string}},
+     *     coverImage: array{filename: string, width: int|null, height: int|null, avif: array{thumbnail: string, small: string, medium: string, large: string, full: string}, webp: array{thumbnail: string, small: string, medium: string, large: string, full: string}, jpg: array{thumbnail: string, small: string, medium: string, large: string, full: string}},
      *     startedAt: string,
      *     endedAt: string|null,
      *     startedAtFormatted: string|null,
@@ -301,6 +301,12 @@ class PublicControllersService
      *      medium: string,
      *      large: string,
      *      full: string,},
+     *  jpg: array{
+     *      thumbnail: string,
+     *      small: string,
+     *      medium: string,
+     *      large: string,
+     *      full: string,},
      * }
      */
     public function formatPictureForSSR(Picture $picture): array
@@ -322,6 +328,13 @@ class PublicControllersService
                 'medium' => $picture->getUrl('medium', 'webp'),
                 'large' => $picture->getUrl('large', 'webp'),
                 'full' => $picture->getUrl('full', 'webp'),
+            ],
+            'jpg' => [
+                'thumbnail' => $picture->getUrl('thumbnail', 'jpg'),
+                'small' => $picture->getUrl('small', 'jpg'),
+                'medium' => $picture->getUrl('medium', 'jpg'),
+                'large' => $picture->getUrl('large', 'jpg'),
+                'full' => $picture->getUrl('full', 'jpg'),
             ],
         ];
     }

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -297,6 +297,13 @@ interface SSRPicture {
         large: string;
         full: string;
     };
+    jpg: {
+        thumbnail: string;
+        small: string;
+        medium: string;
+        large: string;
+        full: string;
+    };
 }
 
 interface SSRCertification {

--- a/tests/Feature/Models/Experience/ExperiencePageControllerTest.php
+++ b/tests/Feature/Models/Experience/ExperiencePageControllerTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Models\Experience;
 
 use App\Http\Controllers\Admin\ExperiencePageController;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;

--- a/tests/Feature/Models/Picture/OptimizedPictureTest.php
+++ b/tests/Feature/Models/Picture/OptimizedPictureTest.php
@@ -71,7 +71,7 @@ class OptimizedPictureTest extends TestCase
     #[Test]
     public function it_defines_format_options_as_constants()
     {
-        $this->assertEquals(['avif', 'webp'], OptimizedPicture::FORMATS);
+        $this->assertEquals(['avif', 'webp', 'jpg'], OptimizedPicture::FORMATS);
     }
 
     #[Test]

--- a/tests/Feature/Models/SocialMediaLink/SocialMediaLinkPageControllerTest.php
+++ b/tests/Feature/Models/SocialMediaLink/SocialMediaLinkPageControllerTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Models\SocialMediaLink;
 
 use App\Http\Controllers\Admin\SocialMediaLinkPageController;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;

--- a/tests/Feature/Models/Technology/TechnologyExperiencePageControllerTest.php
+++ b/tests/Feature/Models/Technology/TechnologyExperiencePageControllerTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Models\Technology;
 
 use App\Http\Controllers\Admin\TechnologyExperiencePageController;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;

--- a/tests/Feature/Services/PublicControllersServiceTest.php
+++ b/tests/Feature/Services/PublicControllersServiceTest.php
@@ -279,6 +279,7 @@ class PublicControllersServiceTest extends TestCase
                 $this->assertEquals($feature->picture->filename, $resultFeature['picture']['filename']);
                 $this->assertArrayHasKey('avif', $resultFeature['picture']);
                 $this->assertArrayHasKey('webp', $resultFeature['picture']);
+                $this->assertArrayHasKey('jpg', $resultFeature['picture']);
             } else {
                 $this->assertNull($resultFeature['picture']);
             }
@@ -306,6 +307,7 @@ class PublicControllersServiceTest extends TestCase
 
             $this->assertArrayHasKey('avif', $resultScreenshot['picture']);
             $this->assertArrayHasKey('webp', $resultScreenshot['picture']);
+            $this->assertArrayHasKey('jpg', $resultScreenshot['picture']);
         }
 
         foreach ($creation->people as $person) {
@@ -326,6 +328,7 @@ class PublicControllersServiceTest extends TestCase
             $this->assertEquals($video->coverPicture->filename, $resultVideo['coverPicture']['filename']);
             $this->assertArrayHasKey('avif', $resultVideo['coverPicture']);
             $this->assertArrayHasKey('webp', $resultVideo['coverPicture']);
+            $this->assertArrayHasKey('jpg', $resultVideo['coverPicture']);
         }
     }
 


### PR DESCRIPTION
- Add 'jpg' to OptimizedPicture::FORMATS enum
- Update Picture model to accept 'jpg' format
- Extend formatPictureForSSR to include jpg urls
- Update type definitions for jpg picture format
- Adjust tests to expect jpg in picture formats