### PR TITLE
feat(data-management): implement background export processing

### DIFF
--- a/app/Http/Controllers/Admin/DataManagementController.php
+++ b/app/Http/Controllers/Admin/DataManagementController.php
@@ -3,17 +3,21 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Jobs\ExportWebsiteJob;
 use App\Services\WebsiteExportService;
 use App\Services\WebsiteImportService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response as ResponseAlias;
 
 /**
  * Controller for managing website data export and import functionality.
@@ -37,24 +41,102 @@ class DataManagementController extends Controller
     }
 
     /**
-     * Export website data to a ZIP file.
+     * Export website data to a ZIP file using background job.
      */
-    public function export(): BinaryFileResponse|JsonResponse
+    public function export(): JsonResponse
     {
-        try {
-            $zipPath = $this->exportService->exportWebsite();
+        $lockKey = 'data_export_lock';
+        $requestId = Str::uuid()->toString();
+        $cacheKey = "data_export_status_{$requestId}";
 
-            // Clean up old exports
-            $this->exportService->cleanupOldExports();
+        // Check if an export is already in progress
+        if (Cache::has($lockKey)) {
+            $existingExport = Cache::get($lockKey);
 
-            return response()->download($zipPath, basename($zipPath), [
-                'Content-Type' => 'application/zip',
-            ])->deleteFileAfterSend(true);
-        } catch (RuntimeException $e) {
             return response()->json([
-                'message' => 'Export failed: '.$e->getMessage(),
-            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+                'status' => 'already_in_progress',
+                'message' => 'An export is already in progress. Please wait for it to complete.',
+                'request_id' => $existingExport['request_id'],
+                'started_at' => $existingExport['started_at'],
+            ], ResponseAlias::HTTP_CONFLICT);
         }
+
+        // Set lock to prevent concurrent exports
+        Cache::put($lockKey, [
+            'request_id' => $requestId,
+            'started_at' => now()->toISOString(),
+        ], now()->addMinutes(20)); // Lock expires after 20 minutes
+
+        // Initialize export status in cache
+        Cache::put($cacheKey, [
+            'status' => 'queued',
+            'request_id' => $requestId,
+            'queued_at' => now()->toISOString(),
+        ], now()->addMinutes(20));
+
+        // Dispatch background job
+        ExportWebsiteJob::dispatch($cacheKey, $requestId);
+
+        return response()->json([
+            'status' => 'accepted',
+            'message' => 'Export request accepted. Processing in background.',
+            'request_id' => $requestId,
+            'status_url' => route('dashboard.data-management.export-status', ['requestId' => $requestId]),
+        ], ResponseAlias::HTTP_ACCEPTED);
+    }
+
+    /**
+     * Get export status for a specific request.
+     */
+    public function exportStatus(string $requestId): JsonResponse
+    {
+        $cacheKey = "data_export_status_{$requestId}";
+        $status = Cache::get($cacheKey);
+
+        if (! $status) {
+            return response()->json([
+                'status' => 'not_found',
+                'message' => 'Export request not found or expired.',
+            ], ResponseAlias::HTTP_NOT_FOUND);
+        }
+
+        // Release lock if export is completed or failed
+        if (in_array($status['status'], ['completed', 'failed'])) {
+            Cache::forget('data_export_lock');
+        }
+
+        return response()->json($status);
+    }
+
+    /**
+     * Download exported file.
+     */
+    public function downloadExport(string $requestId): BinaryFileResponse|JsonResponse
+    {
+        $cacheKey = "data_export_status_{$requestId}";
+        $status = Cache::get($cacheKey);
+
+        if (! $status || $status['status'] !== 'completed') {
+            return response()->json([
+                'status' => 'not_ready',
+                'message' => 'Export not ready for download.',
+            ], ResponseAlias::HTTP_NOT_FOUND);
+        }
+
+        $filePath = $status['file_path'];
+        if (! Storage::exists($filePath)) {
+            return response()->json([
+                'status' => 'file_not_found',
+                'message' => 'Export file not found or expired.',
+            ], ResponseAlias::HTTP_NOT_FOUND);
+        }
+
+        $fullPath = Storage::path($filePath);
+        $fileName = "website-export-{$requestId}-".now()->format('Y-m-d_H-i-s').'.zip';
+
+        return response()->download($fullPath, $fileName, [
+            'Content-Type' => 'application/zip',
+        ]);
     }
 
     /**

--- a/app/Jobs/DeleteExportFileJob.php
+++ b/app/Jobs/DeleteExportFileJob.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Jobs;
+
+use Exception;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Job to automatically delete export files after 15 minutes.
+ */
+class DeleteExportFileJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 60; // 1 minute timeout
+
+    public int $tries = 1; // Single attempt
+
+    public function __construct(
+        private readonly string $filePath,
+        private readonly string $cacheKey
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        try {
+            if (Storage::exists($this->filePath)) {
+                Storage::delete($this->filePath);
+                Log::info('Export file deleted automatically', [
+                    'file_path' => $this->filePath,
+                    'cache_key' => $this->cacheKey,
+                ]);
+            }
+
+            Cache::forget($this->cacheKey);
+        } catch (Exception $e) {
+            Log::error('Failed to delete export file', [
+                'file_path' => $this->filePath,
+                'cache_key' => $this->cacheKey,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Jobs/ExportWebsiteJob.php
+++ b/app/Jobs/ExportWebsiteJob.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Services\WebsiteExportService;
+use Exception;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use League\Flysystem\FilesystemException;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Background job for website data export to prevent controller timeouts.
+ */
+class ExportWebsiteJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 3600; // 1 hour timeout
+
+    public int $tries = 1; // Single attempt
+
+    public function __construct(
+        private readonly string $cacheKey,
+        private readonly string $requestId
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(WebsiteExportService $exportService): void
+    {
+        try {
+            Cache::put($this->cacheKey, [
+                'status' => 'processing',
+                'request_id' => $this->requestId,
+                'started_at' => now()->toISOString(),
+                'progress' => 'Starting export...',
+            ], now()->addMinutes(20));
+
+            $zipPath = $exportService->exportWebsite();
+            $exportService->cleanupOldExports();
+
+            $archiveFileName = "export-{$this->requestId}-".now()->format('Y-m-d_H-i-s').'.zip';
+            $archivePath = "exports/{$archiveFileName}";
+
+            Storage::makeDirectory('exports');
+
+            if (! Storage::move($zipPath, $archivePath)) {
+                throw new RuntimeException('Failed to move export file');
+            }
+
+            $fullArchivePath = Storage::path($archivePath);
+
+            Cache::put($this->cacheKey, [
+                'status' => 'completed',
+                'request_id' => $this->requestId,
+                'started_at' => Cache::get($this->cacheKey)['started_at'] ?? now()->toISOString(),
+                'completed_at' => now()->toISOString(),
+                'file_path' => $archivePath,
+                'file_size' => filesize($fullArchivePath),
+                'download_url' => route('dashboard.data-management.download', ['requestId' => $this->requestId]),
+            ], now()->addMinutes(15));
+
+            DeleteExportFileJob::dispatch($archivePath, $this->cacheKey)
+                ->delay(now()->addMinutes(15));
+
+            Log::info('Website export completed successfully', [
+                'request_id' => $this->requestId,
+                'file_path' => $archivePath,
+                'file_size' => filesize($fullArchivePath),
+            ]);
+
+        } catch (Exception|FilesystemException $e) {
+            Cache::put($this->cacheKey, [
+                'status' => 'failed',
+                'request_id' => $this->requestId,
+                'started_at' => Cache::get($this->cacheKey)['started_at'] ?? now()->toISOString(),
+                'failed_at' => now()->toISOString(),
+                'error' => $e->getMessage(),
+            ], now()->addMinutes(5));
+
+            Log::error('Website export failed', [
+                'request_id' => $this->requestId,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Handle job failure.
+     */
+    public function failed(Throwable $exception): void
+    {
+        Cache::put($this->cacheKey, [
+            'status' => 'failed',
+            'request_id' => $this->requestId,
+            'started_at' => Cache::get($this->cacheKey)['started_at'] ?? now()->toISOString(),
+            'failed_at' => now()->toISOString(),
+            'error' => $exception->getMessage(),
+        ], now()->addMinutes(5));
+
+        Log::error('Website export job failed', [
+            'request_id' => $this->requestId,
+            'error' => $exception->getMessage(),
+            'trace' => $exception->getTraceAsString(),
+        ]);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -107,6 +107,10 @@ Route::name('dashboard.')->prefix('dashboard')->middleware(['auth', 'verified'])
             ->name('index');
         Route::post('/export', [DataManagementController::class, 'export'])
             ->name('export');
+        Route::get('/export/{requestId}/status', [DataManagementController::class, 'exportStatus'])
+            ->name('export-status');
+        Route::get('/export/{requestId}/download', [DataManagementController::class, 'downloadExport'])
+            ->name('download');
         Route::post('/upload', [DataManagementController::class, 'uploadImportFile'])
             ->name('upload');
         Route::post('/import', [DataManagementController::class, 'import'])


### PR DESCRIPTION
- Add background job for website data export to prevent timeouts
- Add export status tracking via cache with request IDs
- Implement export status and download endpoints
- Add concurrent export prevention with cache locks
- Add automatic cleanup of export files after 15 minutes
- Update frontend to handle background export flow
- Improve export service with better error handling
- Add logging for export lifecycle events
- Add tests for new export functionality
- Remove direct export endpoint in favor of async approach